### PR TITLE
Fixed black hole projectile affecting wrong maps

### DIFF
--- a/Source/RimEffectN7/BlackHoleProjectile.cs
+++ b/Source/RimEffectN7/BlackHoleProjectile.cs
@@ -64,9 +64,9 @@ namespace RimEffectN7
 
                 foreach (IntVec3 intVec3 in GenAdj.OccupiedRect(this.DrawPos.ToIntVec3(), this.Rotation, rangeIntVec2))
                 {
-                    if (!intVec3.InBounds(Find.CurrentMap))
+                    if (!intVec3.InBounds(this.Map))
                         continue;
-                    List<Thing> cellThings = Find.CurrentMap.thingGrid.ThingsListAt(intVec3);
+                    List<Thing> cellThings = this.Map.thingGrid.ThingsListAt(intVec3);
                     if (cellThings == null)
                         continue;
 


### PR DESCRIPTION
Right now, it's using Find.CurrentMap, which is the map the player is on - not the projectile. This allowed this projectile to affect different maps instead of the one they were spawned into by just switching the map the player is on.

This fixes this issue by using the actual map it's located in.