### PR TITLE
Fixed dark channel hediff

### DIFF
--- a/1.3/Defs/Abilities/Abilities.xml
+++ b/1.3/Defs/Abilities/Abilities.xml
@@ -7,6 +7,7 @@
         <abilityClass>VFECore.Abilities.Ability_ShootProjectile</abilityClass>
         <targetMode>Pawn</targetMode>
         <castTime>60</castTime>
+        <durationTime>6000</durationTime>
         <range>24</range>
         <iconPath>Things/Abilities/Biotic_DarkChannel</iconPath>
         <power>6</power>
@@ -55,9 +56,7 @@
         <labelNoun>dark channel</labelNoun>
         <description>Painful biotic field that latches onto nearby targets if the target falls unconscious.</description>
         <comps>
-            <li Class="HediffCompProperties_Disappears">
-                <disappearsAfterTicks>6000~6000</disappearsAfterTicks>
-            </li>
+            <li Class="HediffCompProperties_Disappears"/>
             <li>
                 <compClass>RimEffectN7.HediffComp_DarkChannel</compClass>
             </li>


### PR DESCRIPTION
Looking at `VFECore.Abilities.Ability:ApplyHediff`, it uses `durationTime` and applies it to `HediffCompProperties_Disappears`, even if `durationTime` is 0. I believe this was changed at some point, but dark channel ability and hediff weren't updated for that.

This also affects Rim-Effect: Core, for which I've also made a PR.